### PR TITLE
fix: issue-254 Receiver hotplugging and quick discovery

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,7 +9,6 @@ services:
       - spectre-dev-network
     volumes:
       - spectre-dev-data-v4:/app/.spectre-data
-    devices:
       - /dev/bus/usb:/dev/bus/usb
     device_cgroup_rules:
       - "c 189:* rw"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@ services:
       - spectre-network
     volumes:
       - spectre-data-v4:/app/.spectre-data
-    devices:
       - /dev/bus/usb:/dev/bus/usb
     device_cgroup_rules:
       - "c 189:* rw"


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
Receivers are now discovered on the first discovery probe:  

```bash
spectre get receiver -r <receiver>
```

whenever they are plugged in. Now, no more container restarts are required. Sadly, some devices (like those from SDRplay or the RX-888 MK II) still require a couple of discovery probes due to how they initialise over USB.

## Issue link
<!-- Add the link to the related issue(s) -->
[issue-254](https://github.com/spectregrams/spectre/issues/254)

## Checklist before merging
<!-- CI enforces conventional commits, formatting, type-checking, and tests. These items require judgement: -->

- [X] Each commit represents a single, coherent unit of work
- [X] New behaviour is covered by new tests
- [X] Documentation is updated where required

## Additional notes
<!-- Any additional information that reviewers should know -->
> n/a
