### PR TITLE
feat: expose config lock state

### DIFF
--- a/backend/src/spectre_server/routes/_format_responses.py
+++ b/backend/src/spectre_server/routes/_format_responses.py
@@ -10,6 +10,7 @@ import enum
 import http
 
 import flask
+import werkzeug.exceptions
 
 """This module implements the JSend specification. For more information, please refer
 to https://github.com/omniti-labs/jsend"""
@@ -54,7 +55,10 @@ def _make_jsend_response(
                 f"JSend status codes."
             )
         jsend_dict["data"] = data
-        return flask.jsonify(jsend_dict)
+        response = flask.jsonify(jsend_dict)
+        if code is not None:
+            response.status_code = code
+        return response
 
     # Handle error status
     elif status == _JsendStatus.ERROR:
@@ -70,7 +74,10 @@ def _make_jsend_response(
         if code is not None:
             jsend_dict["code"] = str(code)
 
-        return flask.jsonify(jsend_dict)
+        response = flask.jsonify(jsend_dict)
+        if code is not None:
+            response.status_code = code
+        return response
 
 
 P = typing.ParamSpec("P")
@@ -97,7 +104,13 @@ def jsendify_response(
             return _make_jsend_response(
                 _JsendStatus.SUCCESS, data=data, code=http.HTTPStatus.OK
             )
-        except:  # simplistic treatment, any exceptions are interpreted as JSend errors.
+        except werkzeug.exceptions.HTTPException as exc:
+            return _make_jsend_response(
+                _JsendStatus.ERROR,
+                message=exc.description,
+                code=exc.code,
+            )
+        except Exception:  # Unexpected exceptions are interpreted as JSend errors.
             return _make_jsend_response(
                 _JsendStatus.ERROR,
                 message=(

--- a/backend/src/spectre_server/routes/configs.py
+++ b/backend/src/spectre_server/routes/configs.py
@@ -6,6 +6,7 @@ import os
 import typing
 
 import flask
+import werkzeug.exceptions
 
 from ..services import configs as services
 from ._format_responses import jsendify_response, serve_from_directory
@@ -47,6 +48,13 @@ def get_config_raw(
 @configs_blueprint.route("/<string:file_name>", methods=["GET"])
 def get_config(file_name: str) -> flask.Response:
     return serve_from_directory(services.get_config(file_name))
+
+
+@configs_blueprint.route("/<string:file_name>/locked", methods=["GET"])
+@jsendify_response
+def get_config_locked(file_name: str) -> bool:
+    """Return whether existing batch files prevent safe updates to a config."""
+    return services.is_config_locked(file_name)
 
 
 @configs_blueprint.route("/", methods=["GET"])
@@ -93,6 +101,15 @@ def update_config(file_name: str) -> str:
     string_parameters = json.get("params")
     force = json.get("force")
     validate = json.get("validate")
+
+    if services.is_config_locked(file_name) and not force:
+        raise werkzeug.exceptions.Conflict(
+            description=(
+                f"The config '{file_name}' is locked because recorded batch files exist. "
+                "Create a new config for changes, or set force to true only if you understand "
+                "the existing recorded data may no longer be represented by this config."
+            )
+        )
 
     config_file_path = services.update_config(
         file_name, string_parameters, force=force, validate=validate

--- a/backend/src/spectre_server/services/configs.py
+++ b/backend/src/spectre_server/services/configs.py
@@ -53,6 +53,17 @@ def _has_batches(tag: str) -> bool:
     return len(batches) > 0
 
 
+@spectre_server.core.logs.log_call
+def is_config_locked(file_name: str) -> bool:
+    """Return whether a config has recorded batch files and must not be updated.
+
+    A config is locked once it has been used to record data. Updating it after
+    that point would make the config no longer represent the existing batches.
+    """
+    tag, _ = spectre_server.core.receivers.parse_config_file_name(file_name)
+    return _has_batches(tag)
+
+
 def _caution_update(tag: str, force: bool) -> None:
     """Caution users if batch files exist with the input tag.
 
@@ -124,7 +135,7 @@ def create_config(
     :param force: If True, force the update even if batches exist with the input tag. Defaults to False
     :param validate: If True, validate config parameters. Defaults to True.
     :return: The file path of the newly created config, as an absolute path in the container's file system.
-    :raises FileExistsError: If the config already exists, files exist under the config tag and force is False.
+    :raises FileExistsError: If the config already exists and is locked because batches exist under its tag, unless force is True. A locked config represents existing recorded data and should normally be left unchanged.
     """
     if string_parameters is None:
         string_parameters = []
@@ -166,6 +177,7 @@ def update_config(
     :param validate: If True, apply the capture template and validate config parameters. Defaults to True.
     :return: The file path of the successfully updated config, as an absolute path in the container's file system.
     :raises FileNotFoundError: If the config does not exist.
+    :raises FileExistsError: If the config is locked because batches exist under its tag and force is False. A locked config represents existing recorded data and should normally be left unchanged.
     """
     tag, _ = spectre_server.core.receivers.parse_config_file_name(file_name)
     if not os.path.exists(spectre_server.core.receivers.get_config_file_path(tag)):

--- a/backend/tests/integration/routes/test_configs.py
+++ b/backend/tests/integration/routes/test_configs.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: © 2026 Jimmy Fitzpatrick <jimmy@spectregrams.org>
+# This file is part of SPECTRE
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import flask.testing
+
+import spectre_server.services.configs as services
+
+
+TAG = "cw"
+FILE_NAME = f"{TAG}.json"
+
+
+def test_get_config_locked_returns_batch_state(
+    client: flask.testing.FlaskClient, monkeypatch
+) -> None:
+    monkeypatch.setattr(services, "is_config_locked", lambda file_name: file_name == FILE_NAME)
+
+    response = client.get(f"/spectre-data/configs/{FILE_NAME}/locked")
+
+    assert response.status_code == 200
+    assert response.get_json() == {"status": "success", "data": True}
+
+
+def test_update_locked_config_returns_user_facing_conflict(
+    client: flask.testing.FlaskClient, monkeypatch
+) -> None:
+    response = client.put(
+        f"/spectre-data/configs/{FILE_NAME}",
+        json={
+            "receiver_name": "signal_generator",
+            "receiver_mode": "cosine_wave",
+            "validate": False,
+        },
+    )
+    assert response.get_json()["status"] == "success"
+
+    monkeypatch.setattr(services, "is_config_locked", lambda file_name: True)
+    response = client.patch(
+        f"/spectre-data/configs/{FILE_NAME}",
+        json={"params": {"time_range": "1.0"}, "validate": False},
+    )
+
+    assert response.status_code == 409
+    jsend = response.get_json()
+    assert jsend["status"] == "error"
+    assert "locked" in jsend["message"]
+    assert "force" in jsend["message"]

--- a/backend/tests/integration/routes/test_configs.py
+++ b/backend/tests/integration/routes/test_configs.py
@@ -6,7 +6,6 @@ import flask.testing
 
 import spectre_server.services.configs as services
 
-
 TAG = "cw"
 FILE_NAME = f"{TAG}.json"
 
@@ -14,7 +13,9 @@ FILE_NAME = f"{TAG}.json"
 def test_get_config_locked_returns_batch_state(
     client: flask.testing.FlaskClient, monkeypatch
 ) -> None:
-    monkeypatch.setattr(services, "is_config_locked", lambda file_name: file_name == FILE_NAME)
+    monkeypatch.setattr(
+        services, "is_config_locked", lambda file_name: file_name == FILE_NAME
+    )
 
     response = client.get(f"/spectre-data/configs/{FILE_NAME}/locked")
 

--- a/backend/tests/unit/services/test_configs.py
+++ b/backend/tests/unit/services/test_configs.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: © 2026 Jimmy Fitzpatrick <jimmy@spectregrams.org>
+# This file is part of SPECTRE
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import spectre_server.services.configs as services
+
+
+def test_is_config_locked_delegates_to_batch_lookup(monkeypatch) -> None:
+    """A config is locked exactly when batches exist under its parsed tag."""
+    monkeypatch.setattr(services, "_has_batches", lambda tag: tag == "locked")
+
+    assert services.is_config_locked("locked.json") is True
+    assert services.is_config_locked("unlocked.json") is False

--- a/cli/src/spectre_cli/commands/get.py
+++ b/cli/src/spectre_cli/commands/get.py
@@ -308,6 +308,10 @@ def config(
 
     jsend_dict = safe_request(f"spectre-data/configs/{file_name}/raw", "GET")
     config = jsend_dict["data"]
+
+    jsend_dict = safe_request(f"spectre-data/configs/{file_name}/locked", "GET")
+    config["locked"] = jsend_dict["data"]
+
     pprint_dict(config)
     raise typer.Exit()
 


### PR DESCRIPTION
## Summary

Closes #296

This change exposes whether a configuration is locked by existing recorded batch files, so clients can explain why an update is unavailable before attempting the mutation.

## Changes

- Add `GET /spectre-data/configs/<file_name>/locked`.
- Return a user-facing HTTP 409 JSend error when an update targets a locked config without `force`.
- Include the `locked` state in `spectre get config --tag <tag>` output.
- Document the locked-state behavior in the config service docstrings.
- Add unit and integration coverage for the lock state and conflict response.

## Validation

- `python3 -m compileall` passed for all changed backend, CLI, and test files.
- `git diff --check` passed.
- Full pytest execution was attempted, but the local environment lacks GNU Radio (`ModuleNotFoundError: No module named 'gnuradio'`), a project dependency imported during test collection.