### PR TITLE
fix: issue-308 Address window effects in spectrograms

### DIFF
--- a/backend/src/spectre_server/core/events/__init__.py
+++ b/backend/src/spectre_server/core/events/__init__.py
@@ -18,6 +18,7 @@ from ._stfft import (
     get_times,
     get_cosine_signal,
     get_num_spectrums,
+    get_num_dangling_windows,
 )
 
 __all__ = [
@@ -35,5 +36,6 @@ __all__ = [
     "get_times",
     "get_frequencies",
     "get_num_spectrums",
+    "get_num_dangling_windows",
     "get_cosine_signal",
 ]

--- a/backend/src/spectre_server/core/events/_callisto.py
+++ b/backend/src/spectre_server/core/events/_callisto.py
@@ -17,6 +17,7 @@ from ._stfft import (
     get_window,
     get_times,
     get_num_spectrums,
+    get_num_dangling_windows,
     get_frequencies,
     get_fftw_obj,
     stfft,
@@ -135,8 +136,28 @@ class Callisto(Base[CallistoModel, spectre_server.core.batches.CallistoBatch]):
             batch.start_datetime,
         )
 
+        target_time_resolution = max(
+            self.__model.time_resolution, spectrogram.time_resolution
+        )
+
+        # Only ignore leading spectrums if they will be averaged away. We don't want NaN values in the final spectrogram.
+        num_dangling_windows = get_num_dangling_windows(
+            self.__model.window_size, self.__model.window_hop
+        )
+        moving_average_window_size = (
+            spectre_server.core.spectrograms.get_moving_average_window_size(
+                target_time_resolution, spectrogram.time_resolution
+            )
+        )
+        will_average = moving_average_window_size > 1
+        nans_averaged_away = num_dangling_windows < moving_average_window_size
+        if will_average and nans_averaged_away:
+            spectrogram = spectre_server.core.spectrograms.ignore_leading_spectrums(
+                spectrogram, num_dangling_windows
+            )
+
         spectrogram = spectre_server.core.spectrograms.time_average(
-            spectrogram, max(self.__model.time_resolution, spectrogram.time_resolution)
+            spectrogram, target_time_resolution
         )
         spectrogram = spectre_server.core.spectrograms.frequency_average(
             spectrogram,

--- a/backend/src/spectre_server/core/events/_fixed_center_frequency.py
+++ b/backend/src/spectre_server/core/events/_fixed_center_frequency.py
@@ -17,6 +17,7 @@ from ._stfft import (
     get_window,
     get_times,
     get_num_spectrums,
+    get_num_dangling_windows,
     get_frequencies,
     get_fftw_obj,
     stfft,
@@ -120,8 +121,28 @@ class FixedCenterFrequency(
             batch.start_datetime,
         )
 
+        target_time_resolution = max(
+            self.__model.time_resolution, spectrogram.time_resolution
+        )
+
+        # Only ignore leading spectrums if they will be averaged away. We don't want NaN values in the final spectrogram.
+        num_dangling_windows = get_num_dangling_windows(
+            self.__model.window_size, self.__model.window_hop
+        )
+        moving_average_window_size = (
+            spectre_server.core.spectrograms.get_moving_average_window_size(
+                target_time_resolution, spectrogram.time_resolution
+            )
+        )
+        will_average = moving_average_window_size > 1
+        nans_averaged_away = num_dangling_windows < moving_average_window_size
+        if will_average and nans_averaged_away:
+            spectrogram = spectre_server.core.spectrograms.ignore_leading_spectrums(
+                spectrogram, num_dangling_windows
+            )
+
         spectrogram = spectre_server.core.spectrograms.time_average(
-            spectrogram, max(self.__model.time_resolution, spectrogram.time_resolution)
+            spectrogram, target_time_resolution
         )
         spectrogram = spectre_server.core.spectrograms.frequency_average(
             spectrogram,

--- a/backend/src/spectre_server/core/events/_stfft.py
+++ b/backend/src/spectre_server/core/events/_stfft.py
@@ -2,6 +2,8 @@
 # This file is part of SPECTRE
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import math
+
 import numpy as np
 import numpy.typing as npt
 import pyfftw
@@ -150,6 +152,25 @@ def get_num_spectrums(signal_size: int, window_size: int, window_hop: int) -> in
         )
 
     return int((signal_size - np.ceil(window_size / 2)) / window_hop) + 1
+
+
+def get_num_dangling_windows(window_size: int, window_hop: int) -> int:
+    """Compute how many leading windows dangle out of the signal.
+
+    Assumes the first window is centered at the start of the signal (index 0).
+
+    :param window_size: The number of samples in each window.
+    :param window_hop: The number of samples the window advances per frame.
+    :return: The number of leading windows that would dangle outside the signal,
+    applying ``stfft`` with this ``window_size`` and ``window_hop``.
+    """
+    if window_hop < 1:
+        raise ValueError(f"The window hop must be at least one. " f"Got {window_hop}.")
+
+    if window_size < 1:
+        raise ValueError(f"The window size must be at least one. Got {window_size}")
+
+    return math.ceil((window_size // 2) / window_hop)
 
 
 def stfft(

--- a/backend/src/spectre_server/core/spectrograms/__init__.py
+++ b/backend/src/spectre_server/core/spectrograms/__init__.py
@@ -5,11 +5,13 @@
 """Create and transform spectrogram data."""
 
 from ._spectrogram import Spectrogram, FrequencyCut, TimeCut, SpectrumUnit, TimeType
+from ._array_operations import get_moving_average_window_size
 from ._transform import (
     frequency_chop,
     time_chop,
     frequency_average,
     time_average,
+    ignore_leading_spectrums,
     join_spectrograms,
 )
 
@@ -22,6 +24,8 @@ __all__ = [
     "time_chop",
     "frequency_average",
     "time_average",
+    "ignore_leading_spectrums",
     "join_spectrograms",
     "TimeType",
+    "get_moving_average_window_size",
 ]

--- a/backend/src/spectre_server/core/spectrograms/_array_operations.py
+++ b/backend/src/spectre_server/core/spectrograms/_array_operations.py
@@ -3,9 +3,25 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import typing
+import math
 
 import numpy as np
 import numpy.typing as npt
+
+
+def get_moving_average_window_size(target: float, current: float) -> int:
+    """Get the moving average window size required to achieve the ``target`` resolution through
+    a moving average, based on ``current``."""
+    if target < 0 or current < 0:
+        raise ValueError(
+            f"Cannot determine moving average window size for negative resolutions"
+        )
+
+    # The target is not possible, current is best.
+    if target <= current:
+        return 1
+
+    return math.floor(target / current)
 
 
 def moving_average(

--- a/backend/src/spectre_server/core/spectrograms/_transform.py
+++ b/backend/src/spectre_server/core/spectrograms/_transform.py
@@ -3,12 +3,18 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import datetime
-import math
 
 import numpy as np
 
-from ._array_operations import find_closest_index, moving_average, time_elapsed
+from ._array_operations import (
+    find_closest_index,
+    moving_average,
+    time_elapsed,
+    get_moving_average_window_size,
+)
 from ._spectrogram import Spectrogram
+
+# TODO: Reconsider ownership of NumPy arrays on transforms. Currently, callers may find that mutating some arrays in transformed spectrograms corrupts the original.
 
 
 def frequency_chop(
@@ -149,7 +155,10 @@ def time_average(spectrogram: Spectrogram, resolution: float) -> Spectrogram:
             f"Desired time resolution {resolution} must be less than the time range {spectrogram.time_range}"
         )
 
-    window_size = math.floor(resolution / spectrogram.time_resolution)
+    window_size = get_moving_average_window_size(
+        resolution, spectrogram.time_resolution
+    )
+
     transformed_dynamic_spectra = moving_average(
         spectrogram.dynamic_spectra, window_size, axis=1
     )
@@ -186,7 +195,10 @@ def frequency_average(spectrogram: Spectrogram, resolution: float) -> Spectrogra
             f"Desired frequency resolution {resolution} must be less than the frequency range {spectrogram.time_range}"
         )
 
-    window_size = math.floor(resolution / spectrogram.frequency_resolution)
+    window_size = get_moving_average_window_size(
+        resolution, spectrogram.frequency_resolution
+    )
+
     transformed_dynamic_spectra = moving_average(
         spectrogram.dynamic_spectra, window_size, axis=0
     )
@@ -198,6 +210,40 @@ def frequency_average(spectrogram: Spectrogram, resolution: float) -> Spectrogra
         transformed_dynamic_spectra,
         spectrogram.times,
         transformed_frequencies,
+        spectrogram.spectrum_unit,
+        start_datetime=(
+            spectrogram.start_datetime if spectrogram.start_datetime_is_set else None
+        ),
+    )
+
+
+def ignore_leading_spectrums(spectrogram: Spectrogram, n: int) -> Spectrogram:
+    """Mark the first ``n`` spectrums as NaN.
+
+    :param spectrogram: The input spectrogram.
+    :param n: The number of leading spectrums to mark as NaN.
+    :raises ValueError: If ``n`` is negative or greater than the number of spectrums.
+    :return: A new spectrogram with the first ``n`` spectrums NaN'd.
+    """
+    if n < 0:
+        raise ValueError(f"n must be non-negative. Got {n}.")
+
+    if n > spectrogram.num_times:
+        raise ValueError(
+            f"n must be less than the number of spectrums ({spectrogram.num_times}). Got {n}."
+        )
+
+    # Nothing to do.
+    if n == 0:
+        return spectrogram
+
+    transformed_dynamic_spectra = spectrogram.dynamic_spectra.copy()
+    transformed_dynamic_spectra[:, :n] = np.nan
+
+    return Spectrogram(
+        transformed_dynamic_spectra,
+        spectrogram.times,
+        spectrogram.frequencies,
         spectrogram.spectrum_unit,
         start_datetime=(
             spectrogram.start_datetime if spectrogram.start_datetime_is_set else None

--- a/backend/tests/integration/core/test_events.py
+++ b/backend/tests/integration/core/test_events.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: © 2024-2026 Jimmy Fitzpatrick <jimmy@spectregrams.org>
+# This file is part of SPECTRE
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import datetime
+import os
+
+import numpy as np
+
+import spectre_server.core.batches
+import spectre_server.core.config
+import spectre_server.core.events
+import spectre_server.core.fields
+import spectre_server.core.spectrograms
+
+TAG = "fixed-center-frequency-test"
+START = datetime.datetime(year=2000, month=1, day=1, hour=0, minute=0, second=0)
+
+
+def test_fixed_center_frequency(
+    spectre_config_paths: spectre_server.core.config.Paths,
+) -> None:
+    """Check that ``FixedCenterFrequency.process`` produces the expected spectrogram, for constant IQ
+    samples written directly to disk.
+    """
+    amplitude = 2.0
+    window_size = 4
+    window_hop = 4
+    sample_rate = 4.0
+    center_frequency = 100.0
+    signal_size = 16
+
+    model = spectre_server.core.events.FixedCenterFrequencyModel(
+        window_size=window_size,
+        window_hop=window_hop,
+        window_type=spectre_server.core.fields.WindowType.BOXCAR,
+        sample_rate=sample_rate,
+        center_frequency=center_frequency,
+        # Exercise averaging, too.
+        time_resolution=2.0,
+        frequency_resolution=2.0,
+    )
+    receiver = spectre_server.core.events.FixedCenterFrequency(
+        TAG, model, spectre_server.core.batches.IQStreamBatch
+    )
+
+    batches_dir_path = spectre_config_paths.get_batches_dir_path(
+        START.year, START.month, START.day
+    )
+    batch = spectre_server.core.batches.IQStreamBatch(
+        batches_dir_path,
+        datetime.datetime.strftime(
+            START, spectre_server.core.config.TimeFormat.DATETIME
+        ),
+        TAG,
+    )
+
+    # Write some constant I/Q samples to disk.
+    iq_data = np.full(signal_size, amplitude, dtype=np.complex64)
+    os.makedirs(batch.fc32_file.parent_dir_path, exist_ok=True)
+    iq_data.tofile(batch.fc32_file.file_path)
+
+    # Compute the spectrogram.
+    spectrogram = receiver.process(batch)
+
+    # Compare with what's expected.
+    expected_times = np.array([0.0, 2.0], dtype=np.float32)
+    expected_frequencies = np.array([98.5, 100.5], dtype=np.float32)
+    expected_dynamic_spectra = np.array(
+        [
+            [0.0, 0.0],
+            [4.0, 4.0],
+        ],
+        dtype=np.float32,
+    )
+
+    # Check the data arrays.
+    assert np.array_equal(spectrogram.times, expected_times)
+    assert np.array_equal(spectrogram.frequencies, expected_frequencies)
+    assert np.allclose(spectrogram.dynamic_spectra, expected_dynamic_spectra)
+
+    # Check the resolutions are consistent with the model targets.
+    assert np.isclose(model.time_resolution, spectrogram.time_resolution)
+    assert np.isclose(model.frequency_resolution, spectrogram.frequency_resolution)
+
+    # Check the spectrogram start time is consistent with the batch start time.
+    assert spectrogram.start_datetime == np.datetime64(START)
+
+    # Units should be DFT amplitude.
+    assert (
+        spectrogram.spectrum_unit
+        == spectre_server.core.spectrograms.SpectrumUnit.AMPLITUDE
+    )

--- a/backend/tests/unit/core/test_events.py
+++ b/backend/tests/unit/core/test_events.py
@@ -195,6 +195,59 @@ class TestSTFFT:
                 signal_size, window_size, window_hop
             )
 
+    @pytest.mark.parametrize(
+        ("window_size", "window_hop", "expected"),
+        [
+            # Even window size, even hop. Hop greater than size.
+            (4, 6, 1),
+            # Even window size, even hop. Hop equals size.
+            (4, 4, 1),
+            # Even window size even hop. Hop half of size.
+            (4, 2, 1),
+            # Even window size, odd hop. Hop quater of size.
+            (4, 1, 2),
+            # Odd window size, odd hop. Hop equals size.
+            (5, 5, 1),
+            # Odd window size, even hop. Hop less than size.
+            (5, 3, 1),
+            # Odd window size, even hop. Hop less than size.
+            (5, 2, 1),
+            # Smallest possible window.
+            (1, 1, 0),
+            # Small window.
+            (2, 1, 1),
+            (2, 2, 1),
+        ],
+    )
+    def test_num_dangling_windows(
+        self,
+        window_size: int,
+        window_hop: int,
+        expected: int,
+    ) -> None:
+        """Check that we compute the right number of dangling windows."""
+        assert expected == spectre_server.core.events.get_num_dangling_windows(
+            window_size, window_hop
+        )
+
+    @pytest.mark.parametrize(
+        ("window_size", "window_hop"),
+        [
+            # The window size cannot be less than one.
+            (0, 4),
+            # The window hop cannot be less than one.
+            (4, 0),
+        ],
+    )
+    def test_invalid_num_dangling_windows(
+        self,
+        window_size: int,
+        window_hop: int,
+    ) -> None:
+        """Check that passing bad arguments yields a ValueError in various cases."""
+        with pytest.raises(ValueError):
+            spectre_server.core.events.get_num_dangling_windows(window_size, window_hop)
+
     def test_stfft(self) -> None:
         """Check that the stfft of a simple cosine wave matches the analytically derived solution."""
         # Define the cosine wave.

--- a/backend/tests/unit/core/test_spectrograms.py
+++ b/backend/tests/unit/core/test_spectrograms.py
@@ -197,6 +197,108 @@ class TestFrequencyAverage:
         assert np.allclose(averaged_s.times, spectrogram.times)
 
 
+class TestMovingAverage:
+    @pytest.mark.parametrize(
+        ("current", "target", "expected"),
+        [
+            (0.25, 0.5, 2),
+            (0.25, 0.25, 1),
+            (0.25, 0.1, 1),
+            (0.25, 0.33, 1),
+            (0.25, 0.75, 3),
+        ],
+    )
+    def test_get_moving_average_window_size(
+        self, current: float, target: float, expected: int
+    ) -> None:
+        """Make sure we properly compute the size of the window in the moving average to achieve some target resolution."""
+        assert (
+            spectre_server.core.spectrograms.get_moving_average_window_size(
+                target, current
+            )
+            == expected
+        )
+
+    def test_negative_resolution_raises(self) -> None:
+        """Check that trying to determine the moving average window size with negative resolutions raises"""
+        with pytest.raises(ValueError, match="negative resolutions"):
+            spectre_server.core.spectrograms.get_moving_average_window_size(-1, -1)
+
+
+class TestIgnoreNLeading:
+    def test_zero_returns_unchanged(
+        self,
+        spectrogram: spectre_server.core.spectrograms.Spectrogram,
+    ) -> None:
+        """Check that n=0 yields an identical dynamic spectra, with no NaNs introduced."""
+        transformed_s = spectre_server.core.spectrograms.ignore_leading_spectrums(
+            spectrogram, 0
+        )
+        assert np.array_equal(
+            transformed_s.dynamic_spectra, spectrogram.dynamic_spectra
+        )
+        assert not np.any(np.isnan(transformed_s.dynamic_spectra))
+
+        # Other metadata is unchanged.
+        assert np.array_equal(transformed_s.times, spectrogram.times)
+        assert np.array_equal(transformed_s.frequencies, spectrogram.frequencies)
+        assert transformed_s.spectrum_unit == spectrogram.spectrum_unit
+        assert transformed_s.start_datetime_is_set == spectrogram.start_datetime_is_set
+
+    def test_nan_leading(
+        self,
+        spectrogram: spectre_server.core.spectrograms.Spectrogram,
+    ) -> None:
+        """Check that n=2 NaNs the first two columns, leaving the rest (and metadata) unchanged."""
+        transformed_s = spectre_server.core.spectrograms.ignore_leading_spectrums(
+            spectrogram, 2
+        )
+        assert np.all(np.isnan(transformed_s.dynamic_spectra[:, :2]))
+        assert np.array_equal(
+            transformed_s.dynamic_spectra[:, 2:], spectrogram.dynamic_spectra[:, 2:]
+        )
+
+        # Other metadata is unchanged.
+        assert np.array_equal(transformed_s.times, spectrogram.times)
+        assert np.array_equal(transformed_s.frequencies, spectrogram.frequencies)
+        assert transformed_s.spectrum_unit == spectrogram.spectrum_unit
+        assert transformed_s.start_datetime_is_set == spectrogram.start_datetime_is_set
+
+    def test_negative_n_raises(
+        self,
+        spectrogram: spectre_server.core.spectrograms.Spectrogram,
+    ) -> None:
+        """Check that a negative n raises a ValueError."""
+        with pytest.raises(ValueError):
+            spectre_server.core.spectrograms.ignore_leading_spectrums(spectrogram, -1)
+
+    @pytest.mark.parametrize("n", [7, 8])
+    def test_n_exceeds_num_spectrums_raises(
+        self,
+        spectrogram: spectre_server.core.spectrograms.Spectrogram,
+        n: int,
+    ) -> None:
+        """Check that n equal to or greater than the spectrum count raises a ValueError."""
+        with pytest.raises(ValueError):
+            spectre_server.core.spectrograms.ignore_leading_spectrums(spectrogram, n)
+
+    def test_composes_with_time_average(
+        self,
+        spectrogram: spectre_server.core.spectrograms.Spectrogram,
+    ) -> None:
+        """Check that a NaN'd leading spectrum is excluded from a subsequent time average."""
+        transformed_s = spectre_server.core.spectrograms.ignore_leading_spectrums(
+            spectrogram, 1
+        )
+        averaged_s = spectre_server.core.spectrograms.time_average(transformed_s, 0.4)
+        # The first spectrum is excluded from averaging, so the first spectrum in the averaged
+        # spectrogram assumes the value of the second spectrum in the original.
+        assert np.allclose(
+            averaged_s.dynamic_spectra[:, 0], spectrogram.dynamic_spectra[:, 1]
+        )
+        assert not np.any(np.isnan(averaged_s.dynamic_spectra))
+
+
 class TestSpectrogram:
     def test_start_datetime_setter(
         self, spectrogram: spectre_server.core.spectrograms.Spectrogram


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
Mitigate window effects in spectrograms by ignoring spectrums computed using dangling windows during time averaging. This is effected automatically and _only_ when time averaging takes place. 

This change impacts operating modes for any receiver making use of the `FixedCenterFrequency` or `Callisto` event handlers. There's no neater way I can think of to do this when no averaging takes place without riskier changes that disturb our implementation of the STFFT. 

A fix with more longevity may involve a similar approach to the `SweptCenterFrequency` event handler, whereby the previous batch would be cached and prepended where the window dangles providing continuity across batches. This would be a more disruptive change, so can be reserved that for a future release.

## Issue link
<!-- Add the link to the related issue(s) -->
[issue-308](github.com/spectregrams/spectre/issues/308)

## Checklist before merging
<!-- CI enforces conventional commits, formatting, type-checking, and tests. These items require judgement: -->

- [X] Each commit represents a single, coherent unit of work
- [X] New behaviour is covered by new tests
- [X] Documentation is updated where required

## Additional notes
<!-- Any additional information that reviewers should know -->
> n/a
