### PR TITLE
fix: issue-308 Mitigate vertical streaks in spectrograms

### DIFF
--- a/backend/src/spectre_server/core/events/__init__.py
+++ b/backend/src/spectre_server/core/events/__init__.py
@@ -18,6 +18,7 @@ from ._stfft import (
     get_times,
     get_cosine_signal,
     get_num_spectrums,
+    get_num_dangling_samples,
 )
 
 __all__ = [
@@ -35,5 +36,6 @@ __all__ = [
     "get_times",
     "get_frequencies",
     "get_num_spectrums",
+    "get_num_dangling_samples",
     "get_cosine_signal",
 ]

--- a/backend/src/spectre_server/core/events/_callisto.py
+++ b/backend/src/spectre_server/core/events/_callisto.py
@@ -17,6 +17,7 @@ from ._stfft import (
     get_window,
     get_times,
     get_num_spectrums,
+    get_num_dangling_samples,
     get_frequencies,
     get_fftw_obj,
     stfft,
@@ -78,6 +79,12 @@ class Callisto(Base[CallistoModel, spectre_server.core.batches.CallistoBatch]):
         # the watchdog observer isn't set up in time before the receiver starts capturing data.
         self.__fftw_obj = None
 
+        # Cache the last samples from the previous batch so we can eliminate window effects at the start of
+        # the current one. The first batch has no previous, so (by convention) assume the samples are zero.
+        self.__prepend_signal = np.zeros(
+            get_num_dangling_samples(self.__model.window_size), dtype=np.complex64
+        )
+
     @property
     def _watch_extension(self) -> str:
         return self.__model.output_type
@@ -100,6 +107,7 @@ class Callisto(Base[CallistoModel, spectre_server.core.batches.CallistoBatch]):
             iq_data,
             self.__window,
             self.__model.window_hop,
+            prepend_signal=self.__prepend_signal,
         )
 
         # Compute the physical times we'll assign to each spectrum.
@@ -144,6 +152,12 @@ class Callisto(Base[CallistoModel, spectre_server.core.batches.CallistoBatch]):
         )
 
         _LOGGER.info("Spectrogram created successfully")
+
+        # Cache the tail to prepend to the next batch. Copy so the full batch
+        # isn't kept alive by the view.
+        self.__prepend_signal = iq_data[
+            -get_num_dangling_samples(self.__model.window_size) :
+        ].copy()
 
         if not self.__model.keep_signal:
             _LOGGER.info(f"Deleting the I/Q samples")

--- a/backend/src/spectre_server/core/events/_fixed_center_frequency.py
+++ b/backend/src/spectre_server/core/events/_fixed_center_frequency.py
@@ -17,6 +17,7 @@ from ._stfft import (
     get_window,
     get_times,
     get_num_spectrums,
+    get_num_dangling_samples,
     get_frequencies,
     get_fftw_obj,
     stfft,
@@ -67,6 +68,12 @@ class FixedCenterFrequency(
 
         self.__output_type = self.__model.output_type
 
+        # Cache the last samples from the previous batch so we can eliminate window effects at the start of
+        # the current one. The first batch has no previous, so (by convention) assume the samples are zero.
+        self.__prepend_signal = np.zeros(
+            get_num_dangling_samples(self.__model.window_size), dtype=np.complex64
+        )
+
     @property
     def _watch_extension(self) -> str:
         return self.__output_type
@@ -89,6 +96,7 @@ class FixedCenterFrequency(
             iq_data,
             self.__window,
             self.__model.window_hop,
+            prepend_signal=self.__prepend_signal,
         )
 
         # Compute the physical times we'll assign to each spectrum.
@@ -129,6 +137,12 @@ class FixedCenterFrequency(
         )
 
         _LOGGER.info("Spectrogram created successfully")
+
+        # Cache the tail to prepend to the next batch. Copy so the full batch
+        # isn't kept alive by the view.
+        self.__prepend_signal = iq_data[
+            -get_num_dangling_samples(self.__model.window_size) :
+        ].copy()
 
         if not self.__model.keep_signal:
             _LOGGER.info(f"Deleting the I/Q samples")

--- a/backend/src/spectre_server/core/events/_stfft.py
+++ b/backend/src/spectre_server/core/events/_stfft.py
@@ -2,6 +2,8 @@
 # This file is part of SPECTRE
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import typing
+
 import numpy as np
 import numpy.typing as npt
 import pyfftw
@@ -152,12 +154,24 @@ def get_num_spectrums(signal_size: int, window_size: int, window_hop: int) -> in
     return int((signal_size - np.ceil(window_size / 2)) / window_hop) + 1
 
 
+def get_num_dangling_samples(window_size: int) -> int:
+    """Compute the number of samples by which the first window dangles.
+
+    By convention, the first window is centered at the start of the signal (index 0).
+
+    :param window_size: The number of samples in each window.
+    :return: The number of samples by which the first window dangles.
+    """
+    return window_size // 2
+
+
 def stfft(
     fftw_obj: pyfftw.FFTW,
     buffer: npt.NDArray[np.complex64],
     signal: npt.NDArray[np.complex64],
     window: npt.NDArray[np.float32],
     window_hop: int,
+    prepend_signal: typing.Optional[npt.NDArray[np.complex64]] = None,
 ) -> npt.NDArray[np.float32]:
     """Compute the short-time discrete Fourier transform of the input signal, using a real sliding window.
 
@@ -169,9 +183,11 @@ def stfft(
     :param signal: The input signal.
     :param window: The window function, same length as the buffer.
     :param window_hop: The number of samples the window advances per frame.
-    :param sample_rate: The sample rate of the signal.
+    :param prepend_signal: The value assumed by the signal where the window dangles. If not provided (default),
+    by convention those samples are zeroed.
     :return: a spectrogram containing the amplitude of each spectral component.
-    :raises ValueError: If the window and buffer sizes do not match.
+    :raises ValueError: If the window and buffer sizes do not match, or if `prepend_signal` is provided
+    with a length other than `window_size // 2`.
     """
     window_size = window.shape[0]
     buffer_size = buffer.shape[0]
@@ -190,6 +206,15 @@ def stfft(
     # Initialise an empty array, into which we'll copy the spectrums computed by fftw.
     dynamic_spectra = np.empty((window_size, num_spectrums), dtype=np.float32)
 
+    num_dangling_samples = get_num_dangling_samples(window_size)
+    if prepend_signal is None:
+        prepend_signal = np.zeros((num_dangling_samples,), dtype=np.complex64)
+    elif prepend_signal.shape[0] != num_dangling_samples:
+        raise ValueError(
+            f"Must provide exactly {num_dangling_samples} samples to prepend, "
+            f"got {prepend_signal.shape[0]}."
+        )
+
     for n in range(num_spectrums):
         # Center the window for the current frame
         center = window_hop * n
@@ -202,11 +227,17 @@ def stfft(
 
         # The window partially overlaps with the signal.
         else:
-            # Zero the buffer and apply the window only to valid signal samples
             signal_indices = np.arange(start, stop)
-            valid_mask = (signal_indices >= 0) & (signal_indices < signal_size)
-            buffer[:] = 0.0
-            buffer[valid_mask] = signal[signal_indices[valid_mask]] * window[valid_mask]
+
+            out_mask = signal_indices < 0
+            buffer[out_mask] = prepend_signal[
+                signal_indices[out_mask] + num_dangling_samples
+            ]
+
+            in_mask = ~out_mask
+            buffer[in_mask] = signal[signal_indices[in_mask]]
+
+            buffer *= window
 
         # Compute the DFT in-place, to produce the spectrum.
         fftw_obj.execute()

--- a/backend/src/spectre_server/core/spectrograms/_array_operations.py
+++ b/backend/src/spectre_server/core/spectrograms/_array_operations.py
@@ -11,13 +11,16 @@ import numpy.typing as npt
 def moving_average(
     array: npt.NDArray[np.float32], window_size: int, axis: int = 0
 ) -> npt.NDArray[np.float32]:
-    """Applies a moving average along a specified axis by computing the arithmetic mean
-    over non-overlapping but exactly adjacent windows.
+    """Averages ``array`` along ``axis`` in non-overlapping windows of ``window_size``.
+
+    Any trailing samples that do not complete a window are discarded.
 
     :param array: Input array to be averaged.
     :param window_size: Number of items in the window.
     :param axis: Axis along which to perform the averaging, defaults to 0.
     :return: A new array, averaged along the specified axis.
+    :raises ValueError: If ``window_size`` is less than one, or greater than the
+    length of ``axis``.
     """
     if window_size < 1:
         raise ValueError(
@@ -27,36 +30,20 @@ def moving_average(
     axis_length = array.shape[axis]
     if window_size > axis_length:
         raise ValueError(
-            f"The window size ({window_size}) cannot be greater than the length of the axis ({axis})"
-            f"Got axis length {axis_length}"
+            f"The window size ({window_size}) cannot be greater than the length "
+            f"of the axis ({axis}). Got axis length {axis_length}."
         )
-
-    if window_size == 1:
-        # Nothing to do - arithmetic mean of one sample is itself.
-        return array
 
     num_windows = axis_length // window_size
-    remainder = axis_length % window_size
 
-    # Force the axis length to be a multiple of the window size, so if the last window is partial,
-    # we just average over remaining elements.
-    if remainder:
+    slicer = [slice(None)] * array.ndim
+    slicer[axis] = slice(0, num_windows * window_size)
+    trimmed = array[tuple(slicer)]
 
-        # We only need to pad the end of the axis we're averaging over.
-        width = window_size - remainder
-        pad_widths = [(0, 0) for _ in range(array.ndim)]
-        pad_widths[axis] = (0, width)
-
-        # Turn the partial window at the end into a full window.
-        array = np.pad(
-            array, pad_width=pad_widths, mode="constant", constant_values=(np.nan,)
-        )
-        num_windows += 1
-
-    new_shape = list(array.shape)
+    new_shape = list(trimmed.shape)
     new_shape[axis] = num_windows
     new_shape.insert(axis + 1, window_size)
-    return np.nanmean(array.reshape(new_shape), axis=axis + 1)
+    return np.nanmean(trimmed.reshape(new_shape), axis=axis + 1)
 
 
 T = typing.TypeVar("T", np.float32, np.datetime64)

--- a/backend/src/spectre_server/core/spectrograms/_transform.py
+++ b/backend/src/spectre_server/core/spectrograms/_transform.py
@@ -154,9 +154,10 @@ def time_average(spectrogram: Spectrogram, resolution: float) -> Spectrogram:
         spectrogram.dynamic_spectra, window_size, axis=1
     )
 
-    # Assign the start time of each window to as the time of each spectrum in the new spectrogram.
-    # This preserves the time of the first spectrum before and after the transformation.
-    transformed_times = spectrogram.times[0::window_size]
+    # Take the start time of each window. ``moving_average`` drops any trailing
+    # partial window, so slice ``times`` to match.
+    num_windows = transformed_dynamic_spectra.shape[1]
+    transformed_times = spectrogram.times[: num_windows * window_size : window_size]
 
     return Spectrogram(
         transformed_dynamic_spectra,

--- a/backend/tests/integration/core/test_analytical.py
+++ b/backend/tests/integration/core/test_analytical.py
@@ -69,7 +69,8 @@ def _validate_batches(
     spectre_config_paths: spectre_server.core.config.Paths,
 ) -> None:
     signal_generator.mode = config.receiver_mode
-    found_spectrograms = False
+
+    num_validated_batches = 0
     for batch in spectre_server.core.batches.Batches(
         config.tag,
         signal_generator.batch_cls,
@@ -79,7 +80,6 @@ def _validate_batches(
             continue
 
         spectrogram = batch.read_spectrogram()
-        found_spectrograms = True
         result = signal_generator.validate_analytically(
             spectrogram,
             signal_generator.model_validate(config.parameters),
@@ -87,9 +87,16 @@ def _validate_batches(
         )
         assert result["frequencies_validated"]
         assert result["times_validated"]
-        assert 0 <= result["num_invalid_spectrums"] <= 1
 
-    assert found_spectrograms
+        # The first batch should be the only one afflicted by window effects, and so (assuming the hop and size is such that
+        # only one window is dangling in the stfft) we can accept at most one invalid spectrum in that case.
+        max_invalid_spectrums = 1 if num_validated_batches == 0 else 0
+        assert 0 <= result["num_invalid_spectrums"] <= max_invalid_spectrums
+
+        num_validated_batches += 1
+
+    # Check we've validated at least one spectrogram.
+    assert num_validated_batches > 0
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/unit/core/test_events.py
+++ b/backend/tests/unit/core/test_events.py
@@ -195,6 +195,24 @@ class TestSTFFT:
                 signal_size, window_size, window_hop
             )
 
+    @pytest.mark.parametrize(
+        ("window_size", "expected_num_dangling_samples"),
+        [
+            (1, 0),
+            (2, 1),
+            (4, 2),
+            (5, 2),
+        ],
+    )
+    def test_num_dangling_samples(
+        self, window_size: int, expected_num_dangling_samples: int
+    ) -> None:
+        """Check that we compute the number of dangling samples in the first window correctly."""
+        assert (
+            expected_num_dangling_samples
+            == spectre_server.core.events.get_num_dangling_samples(window_size)
+        )
+
     def test_stfft(self) -> None:
         """Check that the stfft of a simple cosine wave matches the analytically derived solution."""
         # Define the cosine wave.
@@ -222,9 +240,7 @@ class TestSTFFT:
             fftw_obj, buffer, signal, window, window_hop
         )
 
-        # TODO: Replace this "point-in-time" check, with something more robust and human readable.
-        # I'll go through the derivation again, and check against a runtime-computed analytical
-        # solution.
+        # The first spectrum is afflicted by window effects.
         expected_dynamic_spectra = np.array(
             [
                 [9.9999994e-01, 0.0, 0.0, 0.0],
@@ -235,6 +251,57 @@ class TestSTFFT:
                 [7.3914812e-08, 0.0, 0.0, 0.0],
                 [1.7320508e00, 0.0, 0.0, 0.0],
                 [2.0000000e00, 4.0, 4.0, 4.0],
+            ],
+            dtype=np.float32,
+        )
+
+        assert is_close(dynamic_spectra, expected_dynamic_spectra)
+
+    def test_stfft_with_prepend_signal(self) -> None:
+        """Check that the stfft of a simple cosine wave matches the analytically derived solution."""
+        # Define the cosine wave.
+        num_samples = 32
+        sample_rate = 8
+        frequency = 1
+        phase = 0
+        amplitude = 1
+
+        # Define the window.
+        window_type = spectre_server.core.fields.WindowType.BOXCAR
+        window_size = 8
+        window_hop = 4
+
+        # Make the full cosine signal, window and buffer.
+        full_signal = spectre_server.core.events.get_cosine_signal(
+            num_samples, sample_rate, frequency, amplitude, phase
+        )
+        window = spectre_server.core.events.get_window(window_type, window_size)
+        buffer = spectre_server.core.events.get_buffer(window_size)
+
+        # Split off the leading samples, and pass them in as the prepended signal.
+        num_dangling_samples = spectre_server.core.events.get_num_dangling_samples(
+            window_size
+        )
+        prepend_signal = full_signal[:num_dangling_samples]
+        signal = full_signal[num_dangling_samples:]
+
+        # Plan, then compute the STFFT.
+        fftw_obj = spectre_server.core.events.get_fftw_obj(buffer)
+        dynamic_spectra = spectre_server.core.events.stfft(
+            fftw_obj, buffer, signal, window, window_hop, prepend_signal
+        )
+
+        # No window effects, every spectrum should be identical.
+        expected_dynamic_spectra = np.array(
+            [
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0],
             ],
             dtype=np.float32,
         )

--- a/backend/tests/unit/core/test_spectrograms.py
+++ b/backend/tests/unit/core/test_spectrograms.py
@@ -81,19 +81,17 @@ class TestTimeAverage:
                 ],
                 [0, 0.4, 0.8],
             ),
-            # Impossible resolution, moving average divides 6 spectra into 1 full window, 1 partial.
+            # Exact resolution, moving average divides 6 spectra into 2 full windows.
             pytest.param(
-                0.85,
-                0.8,
-                [[1.5, 4.5], [7.5, 10.5], [13.5, 16.5], [19.5, 22.5]],
-                [0, 0.8],
-            ),
-            # Exact resolution, moving average divides 6 spectra into 1 full window, 1 partial.
-            pytest.param(
-                0.8,
-                0.8,
-                [[1.5, 4.5], [7.5, 10.5], [13.5, 16.5], [19.5, 22.5]],
-                [0, 0.8],
+                0.65,
+                0.6,
+                [
+                    [1, 4],
+                    [7, 10],
+                    [13, 16],
+                    [19, 22],
+                ],
+                [0, 0.6],
             ),
         ],
     )
@@ -116,6 +114,23 @@ class TestTimeAverage:
         )
         assert np.allclose(averaged_s.times, np.array(expected_times, dtype=np.float32))
         assert np.allclose(averaged_s.frequencies, spectrogram.frequencies)
+
+    def test_averaging_trims_partial_window(self) -> None:
+        """Check the trailing partial window is discarded."""
+        # 7 times at 0.1 s, window=3 yields 2 full windows with 1 trailing sample dropped.
+        dynamic_spectra = np.arange(14, dtype=np.float32).reshape(2, 7)
+        times = np.linspace(0.0, 0.6, 7, dtype=np.float32)
+        frequencies = np.array([1e6, 2e6], dtype=np.float32)
+        spectrogram = spectre_server.core.spectrograms.Spectrogram(
+            dynamic_spectra,
+            times,
+            frequencies,
+            spectre_server.core.spectrograms.SpectrumUnit.AMPLITUDE,
+        )
+        averaged_s = spectre_server.core.spectrograms.time_average(spectrogram, 0.35)
+        assert averaged_s.dynamic_spectra.shape == (2, 2)
+        assert np.allclose(averaged_s.dynamic_spectra, [[1, 4], [8, 11]])
+        assert np.allclose(averaged_s.times, [0.0, 0.3])
 
 
 class TestFrequencyAverage:
@@ -195,6 +210,28 @@ class TestFrequencyAverage:
             np.array(expected_frequencies, dtype=np.float32),
         )
         assert np.allclose(averaged_s.times, spectrogram.times)
+
+    def test_averaging_trims_partial_window(self) -> None:
+        """Check the trailing partial window is discarded."""
+        # 5 frequencies at 1 MHz, window=2 yields 2 full windows with 1 trailing bin dropped.
+        dynamic_spectra = np.arange(15, dtype=np.float32).reshape(5, 3)
+        times = np.array([0.0, 0.2, 0.4], dtype=np.float32)
+        frequencies = np.array([1e6, 2e6, 3e6, 4e6, 5e6], dtype=np.float32)
+        spectrogram = spectre_server.core.spectrograms.Spectrogram(
+            dynamic_spectra,
+            times,
+            frequencies,
+            spectre_server.core.spectrograms.SpectrumUnit.AMPLITUDE,
+        )
+        averaged_s = spectre_server.core.spectrograms.frequency_average(
+            spectrogram, 2e6
+        )
+        assert averaged_s.dynamic_spectra.shape == (2, 3)
+        assert np.allclose(
+            averaged_s.dynamic_spectra,
+            [[1.5, 2.5, 3.5], [7.5, 8.5, 9.5]],
+        )
+        assert np.allclose(averaged_s.frequencies, [1.5e6, 3.5e6])
 
 
 class TestSpectrogram:


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
A root cause analysis found that the vertical streaks in spectrograms had two contributing factors: 

- Artifacts from the Short-time FFT (STFFT) due to dangling windows at the start of batches.
- The final window of the moving average used to average spectrograms in time sometimes contained too few samples. 

So, to address this:  

- Eliminate window effects at the start of batches by (effectively) prepending the last samples of the previous before applying the Short-Time FFT.
- Discard trailing samples during moving averages.

## Issue link
<!-- Add the link to the related issue(s) -->
[issue-308](https://github.com/spectregrams/spectre/issues/308)

## Checklist before merging
<!-- CI enforces conventional commits, formatting, type-checking, and tests. These items require judgement: -->

- [X] Each commit represents a single, coherent unit of work
- [X] New behaviour is covered by new tests
- [X] Documentation is updated where required

## Additional notes
<!-- Any additional information that reviewers should know -->
> n/a
